### PR TITLE
robust fix,validation needed

### DIFF
--- a/tasks/test.js
+++ b/tasks/test.js
@@ -1,4 +1,4 @@
-import request from '../framework/request'
+// import request from '../framework/request'
 import { getReturnBackInfo } from '../apis/phpApis'
 
 export default () => {


### PR DESCRIPTION
之前在发送交易时出现了以太坊钱包客户端链接失败的情况,
该问题导致了某些并行发送的交易发送失败,
抛出了错误后进程关闭.

**这样一个潜在的问题就是已经成功创建了的转账交易并没有获取到确切的成功消息(拿到txid),
所以后续同步成功交易到服务器的函数没有能够继续执行.**
下次启动程序时,上一次已经发送过的用户地址也会从接口里返回,
因而导致了7笔重复发送的转账交易.

本次尝试从以下几点修复:
- 在发送交易出现错误时仍然优先同步成功交易信息到服务器(但是由于调用钱包客户端转账是异步任务,并不能保证所有成功发送的交易在这时都可以返回对应的 txid ,也就是同步的时候会出现遗漏)
- 在调用钱包客户端发送地址之前将地址标记为已发送,这样无论发送成功还是失败,在当前会话中再次勾选需要发送的地址就会过滤掉已经发送的地址.(但是由于没有持久化保存信息,所以退出进程后会失效)

以上虽然可以减少重复发送的可能性,**但是理论上还是不能完全避免**

**所以,最稳妥的办法还是像分发 cre 时一样,提供一个标记已经发送完成的接口,
每次即将调用钱包进行转账前将该地址标记为已发送
下次获取列表时忽略掉已发送和发送成功的地址信息
这样即便是转账失败,也只可能是漏发**

只需要发送完毕之后重新校对已经发送但是尚未标记为发送成功的地址信息即可